### PR TITLE
Fix sorting of database resources

### DIFF
--- a/src/main/xar-resources/modules/explorer.xqm
+++ b/src/main/xar-resources/modules/explorer.xqm
@@ -35,11 +35,11 @@ function exp:describe-collection($uri) as map(xs:string, xs:string) {
         exp:collection-properties($uri),
         map {
             "collections": array {
-                xmldb:get-child-collections($uri) ! exp:collection-properties($uri || "/" || .)
+                (xmldb:get-child-collections($uri) => sort()) ! exp:collection-properties($uri || "/" || .)
 
             },
             "documents": array {
-                xmldb:get-child-resources($uri) ! exp:describe-document($uri || "/" || .)
+                (xmldb:get-child-resources($uri) => sort()) ! exp:describe-document($uri || "/" || .)
             }
         }
     ))


### PR DESCRIPTION
Before, collections and resources were not sorted in any particular order:

> ![screen shot 2019-01-27 at 5 54 39 pm](https://user-images.githubusercontent.com/59118/51808033-a578be00-225c-11e9-848e-25eb8db5e306.png)

After, they are sorted alphabetically:

> ![screen shot 2019-01-27 at 5 49 18 pm](https://user-images.githubusercontent.com/59118/51808019-6d717b00-225c-11e9-9088-8afe4af87014.png)
