### PR TITLE
Test should not rely on ordering of entries in a JSON Map

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit</artifactId>
+            <version>2.25.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/test/java/com/fusiondb/studio/api/QueryIT.java
+++ b/src/test/java/com/fusiondb/studio/api/QueryIT.java
@@ -30,8 +30,11 @@ import static io.restassured.http.ContentType.BINARY;
 import static io.restassured.http.ContentType.JSON;
 import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.apache.http.HttpStatus.*;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 
 public class QueryIT {
 
@@ -276,7 +279,9 @@ public class QueryIT {
         then().
                 statusCode(SC_OK).
         assertThat().
-                body("results", is("{\"a\":\"b\",\"x\":[\"y\",\"z\"],\"t\":true,\"f\":false}"));
+                body("results", jsonEquals("{\"a\":\"b\",\"x\":[\"y\",\"z\"],\"t\":true,\"f\":false}")).
+                and().
+                body("results", not(containsString("\n")));
     }
 
     @Test
@@ -300,11 +305,10 @@ public class QueryIT {
         then().
                 statusCode(SC_OK).
         assertThat().
-                body("results", is("{\n" +
-                        "  \"a\" : \"b\",\n" +
-                        "  \"x\" : [ \"y\", \"z\" ],\n" +
-                        "  \"t\" : true,\n" +
-                        "  \"f\" : false\n" +
-                        "}"));
+                body("results", jsonEquals("{\"a\":\"b\",\"x\":[\"y\",\"z\"],\"t\":true,\"f\":false}")).
+                and().
+                body("results", containsString("{\n")).
+                and().
+                body("results", containsString("\n}"));
     }
 }


### PR DESCRIPTION
Fixes an issue where a test had expected a specific ordering of map items