### PR TITLE
Add .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,41 @@
+version: 2.1
+
+# TODO(DP): lets prune this see #30 #36 #35 
+# matrix:
+#   parameters: 
+#     image_tag: ['latest', '5.0.0', '5.2.0', 'nightly', '1.0.0-ALPHA3']
+#     image_name: ['existdb/existdb', 'evolvedbinary/fusiondb-server']
+#     image_port: ['4059', '8080']
+#     repo: ['repo.evolvedbinary.com:9543', 'repo.evolvedbinary.com:9443', 'default']
+
+
+# xenial uses Java 8 by default we need a VM executor for now
+executors:
+  xenial:
+    machine:
+      image: ubuntu-1604:202007-01
+
+# see https://circleci.com/developer/orbs/orb/circleci/maven orb config
+# next up inline orbing it:
+# see https://circleci.com/docs/2.0/reusing-config/#writing-inline-orbs
+orbs:
+  maven: circleci/maven@1.1.1
+
+workflows:
+  maven_test:
+    jobs:
+      - maven/test:
+          matrix:
+            parameters:
+              command: 
+                - 'verify -B -q -Ddocker.test.port=$FS_API_PORT -Ddocker.test.image=existdb/existdb:latest'
+                - 'verify -B -q -Ddocker.test.port=$FS_API_PORT -Ddocker.test.image=existdb/existdb:5.2.0'
+                - 'verify -B -q -Ddocker.test.port=$FS_API_PORT -Ddocker.test.image=existdb/existdb:5.0.0'
+                # - 'verify -B -q -Ddocker.username=$FDB_NIGHTLY_DOCKER_USER -Ddocker.password=$FDB_NIGHTLY_DOCKER_PASS -Ddocker.test.port=4059 -Ddocker.test.image=$repo.evolvedbinary.com:9543/evolvedbinary/fusiondb-server:nightly'
+                # - 'verify -B -q -Ddocker.username=$FDB_DOCKER_USER -Ddocker.password=$FDB_DOCKER_PASS -Ddocker.test.port=4059 -Ddocker.test.image=$repo.evolvedbinary.com:9443/evolvedbinary/fusiondb-server:1.0.0-ALPHA3'
+          executor: 'xenial'    
+          context: FusionDB_images
+          test_results_path: target/failsafe-reports
+   
+
+


### PR DESCRIPTION
Due to #36 we can't simply expand this to the Fusion Images. So exist 3x it is for now. We should address
#37 #35 #30 before revisiting this config file. 

High up on the list is switching to a container based exectuor similar to [circleci-no-orb](https://github.com/evolvedbinary/fusion-studio-api/blob/circleci-no-orb/.circleci/config.yml) branch, however, to do so while reusing the orb if possible. 

close #31 #32