### PR TITLE
Avoid JSON null returned by eXist-db

### DIFF
--- a/src/main/xar-resources/api.xqm
+++ b/src/main/xar-resources/api.xqm
@@ -64,7 +64,8 @@ function api:version() {
                 "revision": system:get-revision(),
                 "build": system:get-build(),
                 "exist-db": map {
-                    "compatible-version": util:system-property("exist-db-compatible-version")
+                    (: if there is no exist-db-compatible-version (i.e. eXist-db server), then use the system version :)
+                    "compatible-version": (util:system-property("exist-db-compatible-version"), system:get-version())[1]
                 }
             }
         }

--- a/src/test/java/com/fusiondb/studio/api/VersionIT.java
+++ b/src/test/java/com/fusiondb/studio/api/VersionIT.java
@@ -19,20 +19,43 @@ package com.fusiondb.studio.api;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 import static com.fusiondb.studio.api.API.getApiBaseUri;
 import static io.restassured.RestAssured.when;
 import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
 import static org.apache.http.HttpStatus.SC_OK;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class VersionIT {
 
     @Test
-    public void getServerVersion() {
+    public void getVersion() {
         when().
                 get(getApiBaseUri() + "/version").
         then().
                 statusCode(SC_OK).
         assertThat().
                 body(matchesJsonSchemaInClasspath("version-schema.json"));
+    }
+
+    @Test
+    public void existCompatibleVersionIsNotNull() {
+        final Object existDbJson = when().
+                get(getApiBaseUri() + "/version").
+                then().
+                statusCode(SC_OK).
+                assertThat().
+                body(matchesJsonSchemaInClasspath("version-schema.json"))
+                .extract()
+                .jsonPath().get("server.exist-db");
+        assertNotNull(existDbJson);
+        assertTrue(existDbJson instanceof Map);
+
+        final Map<String, Object> map = (Map<String, Object>) existDbJson;
+        if (map.containsKey("compatible-version")) {
+            assertNotNull(map.get("compatible-version"));
+        }
     }
 }

--- a/src/test/resources/version-schema.json
+++ b/src/test/resources/version-schema.json
@@ -6,12 +6,13 @@
   "properties" : {
     "version": {
       "type": "string",
-      "description": "version string",
+      "description": "Version string",
       "example": "1.2.3"
     },
     "server": {
       "type": "object",
-      "description": "server version",
+      "description": "Server version",
+      "required" : [ "version" ],
       "properties": {
         "product-name": {
           "type": "string"
@@ -25,6 +26,16 @@
         },
         "build": {
           "type": "string"
+        },
+        "exist-db": {
+          "type": "object",
+          "description": "eXist-db compatibility",
+          "properties": {
+            "compatible-version": {
+              "type": "string",
+              "example": "1.2.3"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Previously the version end-point would cause a `null` to appear in the `exist-db-compatible-version` property when used on eXist-db. This PR now causes eXist-db to also report its version number as the `exist-db-compatible-version`.